### PR TITLE
Complete canvas test coverage, fix bugs

### DIFF
--- a/src/elements/visual/canvas.ts
+++ b/src/elements/visual/canvas.ts
@@ -146,11 +146,7 @@ export class Canvas2DCanvasElement extends c2dStandaloneChildren(C2DBase) {
   set background(value) {
     if (this.#background.toString() === value.toString()) return;
 
-    this.#background = value;
-
-    this.setAttribute("background", value.toString());
-
-    this.queueRender();
+    this.registerChange("background", (this.#background = value));
   }
 
   /**
@@ -273,9 +269,7 @@ export class Canvas2DCanvasElement extends c2dStandaloneChildren(C2DBase) {
 
     this.domCanvas.width = value * devicePixelRatio;
 
-    this.setAttribute("width", String(value));
-
-    this.queueRender();
+    this.registerChange("width", value);
   }
 
   /**
@@ -295,12 +289,12 @@ export class Canvas2DCanvasElement extends c2dStandaloneChildren(C2DBase) {
 
     this.domCanvas.height = value * devicePixelRatio;
 
-    this.setAttribute("height", String(value));
-
-    this.queueRender();
+    this.registerChange("height", value);
   }
 
   #render() {
+    if (this.#waitFor.size) return;
+
     this.#frame++;
 
     const context = this.#context;
@@ -363,8 +357,6 @@ export class Canvas2DCanvasElement extends c2dStandaloneChildren(C2DBase) {
     this.domCanvas.style.scale = `${1 / newPixelRatio}`;
 
     this.#devicePixelRatio = newPixelRatio;
-
-    this.queueRender();
   }
 
   waitFor(element: Element, eventName: keyof HTMLElementEventMap = "load") {

--- a/tests/c2d-canvas.test.ts
+++ b/tests/c2d-canvas.test.ts
@@ -250,6 +250,48 @@ describe("c2d-canvas", () => {
     }
   });
 
+  test("mouse", async () => {
+    const { mouse } = canvas;
+
+    expect(mouse.x).toBe(0);
+
+    expect(mouse.y).toBe(0);
+
+    expect(mouse.over).toBe(false);
+
+    expect(mouse.buttonStates.every((state) => !state)).toBe(true);
+
+    const x = 50;
+
+    const y = 75;
+
+    await user.pointer([
+      { coords: { x: 0, y: 0 } },
+      {
+        target: canvas.domCanvas,
+        coords: { x, y },
+      },
+    ]);
+
+    expect(mouse.x).toBe(x);
+
+    expect(mouse.y).toBe(y);
+
+    expect(mouse.over).toBe(true);
+
+    await user.pointer({ keys: "[MouseLeft>]" });
+
+    expect(mouse.buttonStates[0]).toBe(true);
+
+    expect(mouse.buttonStates[2]).toBe(false);
+
+    await user.pointer({ keys: "[/MouseLeft][MouseRight>]" });
+
+    expect(mouse.buttonStates[0]).toBe(false);
+
+    expect(mouse.buttonStates[2]).toBe(true);
+  });
+
   test("queueRender", async () => {
     expect(canvas.frame).toBe(0);
 

--- a/tests/c2d-canvas.test.ts
+++ b/tests/c2d-canvas.test.ts
@@ -307,10 +307,34 @@ describe("c2d-canvas", () => {
 
     canvas.renderOn("click");
 
-    user.click(canvas);
+    await user.click(canvas.domCanvas);
 
     await waitFor(() => {
       expect(canvas.frame).toBe(1);
+    });
+  });
+
+  test("waitFor", async () => {
+    const waitElement = document.createElement("a");
+
+    canvas.waitFor(waitElement, "click");
+
+    const everyFrame = jest.fn();
+
+    canvas.everyFrame = everyFrame;
+
+    await new Promise(requestAnimationFrame);
+
+    expect(everyFrame).not.toHaveBeenCalled();
+
+    expect(canvas.frame).toBe(0);
+
+    await user.click(waitElement);
+
+    await waitFor(() => {
+      expect(everyFrame).toHaveBeenCalled();
+
+      expect(canvas.frame).toBeGreaterThan(0);
     });
   });
 });


### PR DESCRIPTION
- Fix renderOn test, which was not passing based on canvas automatically rendering
- Register change when setting width, height, or background on canvas instead of manually queueing render
- Don't render if waiting