### PR TITLE
Fix bug with Vector2D toString precision, test revisions

### DIFF
--- a/src/classes/vector2d.ts
+++ b/src/classes/vector2d.ts
@@ -69,10 +69,10 @@ export class Vector2D extends State<Vector2DBase> {
   toString() {
     const xString = Number.isInteger(this.x)
       ? this.x.toString()
-      : this.x.toPrecision(3);
+      : this.x.toFixed(1);
     const yString = Number.isInteger(this.y)
       ? this.y.toString()
-      : this.y.toPrecision(3);
+      : this.y.toFixed(1);
 
     return `${xString}, ${yString}`;
   }

--- a/src/mixins/transform.ts
+++ b/src/mixins/transform.ts
@@ -142,8 +142,8 @@ export function baseTransform<B extends typeof CustomHTMLElement>(Base: B) {
             this.angularVelocity = attributeParser.Angle(newValue);
             break;
           case "anchor":
-            const newAnchor = attributeParser.Vector2D(newValue);
-            if (!this.#anchor.equals(newAnchor)) this.anchor = newAnchor;
+            if (this.#anchor.toString() !== newValue)
+              this.anchor = attributeParser.Vector2D(newValue);
             break;
           case "scale":
             const newScale = attributeParser.Vector2D(newValue);

--- a/tests/c2d-bezier.test.ts
+++ b/tests/c2d-bezier.test.ts
@@ -8,6 +8,10 @@ import { testStroke } from "./testStroke";
 import { testFill } from "./testFill";
 import { ElementTestSetup } from "./types";
 import { testShadow } from "./testShadow";
+import {
+  Canvas2DBezier,
+  Canvas2DShapeBezier,
+} from "../dist/types/elements/visual/bezier";
 
 function testControlPoints(
   setup: ElementTestSetup<{ controlA: Vector2D; controlB: Vector2D }>
@@ -41,7 +45,7 @@ function testControlPoints(
     });
 
     test("controlB coordinates passed into bezierCurveTo", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const controlB = Vector2D.xy(3, 4);
 
@@ -57,14 +61,18 @@ function testControlPoints(
           controlB.y,
         ]);
       });
+
+      teardown();
     });
 
     test("controlB reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.controlB = Vector2D.xy(3, 4);
 
       testReflection(element, "controlB", "control-b", Vector2D.xy(6, 5));
+
+      teardown();
     });
   });
 }
@@ -72,7 +80,7 @@ function testControlPoints(
 function testTo(setup: ElementTestSetup<{ to: Vector2D }>) {
   describe("to", () => {
     test("coordinates passed into bezierCurveTo", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const to = Vector2D.xy(1, 2);
 
@@ -85,14 +93,18 @@ function testTo(setup: ElementTestSetup<{ to: Vector2D }>) {
 
         expect(bezierCurveTo.mock.calls[0].slice(4)).toEqual([to.x, to.y]);
       });
+
+      teardown();
     });
 
     test("reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.to = Vector2D.xy(1, 2);
 
       testReflection(element, "to", "to", Vector2D.xy(4, 3));
+
+      teardown();
     });
   });
 }
@@ -102,14 +114,14 @@ describe("c2d-bezier", () => {
 
   setupJestCanvasMock();
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DBezier> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
 
     const bezier = canvas.bezier();
 
-    return { canvas, element: bezier };
+    return { canvas, element: bezier, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {
@@ -118,7 +130,7 @@ describe("c2d-bezier", () => {
 
   describe("from", () => {
     test("coordinates passed into moveTo", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const from = Vector2D.xy(1, 2);
 
@@ -131,14 +143,18 @@ describe("c2d-bezier", () => {
 
         expect(moveTo.mock.calls[0]).toEqual([from.x, from.y]);
       });
+
+      teardown();
     });
 
     test("reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.from = Vector2D.xy(1, 2);
 
       testReflection(element, "from", "from", Vector2D.xy(4, 3));
+
+      teardown();
     });
   });
 
@@ -156,7 +172,7 @@ describe("c2d-bezier", () => {
 });
 
 describe("c2d-shape-bezier", () => {
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DShapeBezier> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -165,7 +181,7 @@ describe("c2d-shape-bezier", () => {
 
     const bezier = shape.bezier();
 
-    return { canvas, element: bezier };
+    return { canvas, element: bezier, teardown: root.remove.bind(root) };
   };
 
   testTo(setup);

--- a/tests/c2d-ellipse.test.ts
+++ b/tests/c2d-ellipse.test.ts
@@ -10,13 +10,17 @@ import { waitFor } from "@testing-library/dom";
 import { testOffset } from "./testOffset";
 import { ElementTestSetup } from "./types";
 import { testShadow } from "./testShadow";
+import {
+  Canvas2DEllipse,
+  Canvas2DShapeEllipse,
+} from "../dist/types/elements/visual/ellipse";
 
 function testStartEndAngles(
   setup: ElementTestSetup<{ startAngle: Angle; endAngle: Angle }>
 ) {
   describe("start and end angle", () => {
     test("values are passed to render function", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const render = jest.spyOn(canvas.context, "ellipse");
 
@@ -35,10 +39,12 @@ function testStartEndAngles(
 
         expect(render.mock.calls[0][6]).toBe(endAngle.radians);
       });
+
+      teardown();
     });
 
     test("reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.startAngle = Angle.degrees(30);
 
@@ -47,6 +53,8 @@ function testStartEndAngles(
       testReflection(element, "startAngle", "start-angle", Angle.degrees(60));
 
       testReflection(element, "endAngle", "end-angle", Angle.degrees(30));
+
+      teardown();
     });
   });
 }
@@ -56,14 +64,14 @@ describe("c2d-ellipse", () => {
 
   setupJestCanvasMock();
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DEllipse> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
 
     const ellipse = canvas.ellipse();
 
-    return { canvas, element: ellipse };
+    return { canvas, element: ellipse, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {
@@ -86,7 +94,7 @@ describe("c2d-ellipse", () => {
 });
 
 describe("c2d-shape-ellipse", () => {
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DShapeEllipse> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -95,7 +103,7 @@ describe("c2d-shape-ellipse", () => {
 
     const ellipse = shape.ellipse();
 
-    return { canvas, element: ellipse };
+    return { canvas, element: ellipse, teardown: root.remove.bind(root) };
   };
 
   testStartEndAngles(setup);

--- a/tests/c2d-image.test.ts
+++ b/tests/c2d-image.test.ts
@@ -5,6 +5,8 @@ import { testTransform } from "./testTransform";
 import { testRectangleBounds } from "./testRectangleBounds";
 import { testOffset } from "./testOffset";
 import { testShadow } from "./testShadow";
+import { ElementTestSetup } from "./types";
+import { Canvas2DImage } from "../dist/types/elements/visual/image";
 
 describe("c2d-image", () => {
   mockMatchMedia();
@@ -15,7 +17,7 @@ describe("c2d-image", () => {
 
   const imageHeight = 45;
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DImage> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -28,7 +30,7 @@ describe("c2d-image", () => {
 
     image.mediaElement.height = imageHeight;
 
-    return { canvas, element: image };
+    return { canvas, element: image, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {

--- a/tests/c2d-line.test.ts
+++ b/tests/c2d-line.test.ts
@@ -7,6 +7,10 @@ import { testStroke } from "./testStroke";
 import { waitFor } from "@testing-library/dom";
 import { ElementTestSetup } from "./types";
 import { testShadow } from "./testShadow";
+import {
+  Canvas2DLine,
+  Canvas2DShapeLine,
+} from "../dist/types/elements/visual/line";
 
 function testTo(setup: ElementTestSetup<{ to: Vector2D }>) {
   describe("to", () => {
@@ -41,14 +45,14 @@ describe("c2d-line", () => {
 
   setupJestCanvasMock();
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DLine> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
 
     const line = canvas.line();
 
-    return { canvas, element: line };
+    return { canvas, element: line, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {
@@ -107,7 +111,7 @@ describe("c2d-line", () => {
 });
 
 describe("c2d-shape-line", () => {
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DShapeLine> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -116,7 +120,7 @@ describe("c2d-shape-line", () => {
 
     const line = shape.line();
 
-    return { canvas, element: line };
+    return { canvas, element: line, teardown: root.remove.bind(root) };
   };
 
   testTo(setup);

--- a/tests/c2d-rectangle.test.ts
+++ b/tests/c2d-rectangle.test.ts
@@ -10,6 +10,10 @@ import { testTransform } from "./testTransform";
 import { testOffset } from "./testOffset";
 import { ElementTestSetup } from "./types";
 import { testShadow } from "./testShadow";
+import {
+  Canvas2DRectangle,
+  Canvas2DShapeRectangle,
+} from "../dist/types/elements/visual/rectangle";
 
 function testBorderRadius(
   setup: ElementTestSetup<{
@@ -21,7 +25,7 @@ function testBorderRadius(
 ) {
   describe("border radius", () => {
     test("dimensions are passed into render function with border radius", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const roundRect = jest.spyOn(canvas.context, "roundRect");
 
@@ -42,10 +46,12 @@ function testBorderRadius(
 
         expect(roundRect.mock.calls[0][3]).toBe(height);
       });
+
+      teardown();
     });
 
     test("renders with border radius single value", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const roundRect = jest.spyOn(canvas.context, "roundRect");
 
@@ -65,10 +71,12 @@ function testBorderRadius(
 
         expect(radii).toEqual([radius, radius, radius, radius]);
       });
+
+      teardown();
     });
 
     test("render with border radius object", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const roundRect = jest.spyOn(canvas.context, "roundRect");
 
@@ -98,10 +106,12 @@ function testBorderRadius(
 
         expect(radii).toEqual([topLeft, topRight, bottomRight, bottomLeft]);
       });
+
+      teardown();
     });
 
     test("responds to border radius state change", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const roundRect = jest.spyOn(canvas.context, "roundRect");
 
@@ -144,10 +154,12 @@ function testBorderRadius(
           bottomLeft,
         ]);
       });
+
+      teardown();
     });
 
     test("reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       testReflection(
         element,
@@ -155,6 +167,8 @@ function testBorderRadius(
         "border-radius",
         new BorderRadius(5)
       );
+
+      teardown();
     });
   });
 }
@@ -164,7 +178,7 @@ describe("c2d-rectangle", () => {
 
   setupJestCanvasMock();
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DRectangle> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -175,7 +189,7 @@ describe("c2d-rectangle", () => {
 
     const rectangle = canvas.rectangle();
 
-    return { canvas, element: rectangle };
+    return { canvas, element: rectangle, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {
@@ -198,7 +212,7 @@ describe("c2d-rectangle", () => {
 });
 
 describe("c2d-shape-rectangle", () => {
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DShapeRectangle> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -211,7 +225,7 @@ describe("c2d-shape-rectangle", () => {
 
     const rectangle = shape.rectangle();
 
-    return { canvas, element: rectangle };
+    return { canvas, element: rectangle, teardown: root.remove.bind(root) };
   };
 
   testTransform(setup, 1);

--- a/tests/c2d-shape.test.ts
+++ b/tests/c2d-shape.test.ts
@@ -8,20 +8,22 @@ import { mockMatchMedia, testReflection } from "./shared";
 import { testTransform } from "./testTransform";
 import { waitFor } from "@testing-library/dom";
 import { testShadow } from "./testShadow";
+import { ElementTestSetup } from "./types";
+import { Canvas2DShape } from "../dist/types/elements/visual/shape";
 
 describe("c2d-shape", () => {
   setupJestCanvasMock();
 
   mockMatchMedia();
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DShape> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
 
     const shape = canvas.shape();
 
-    return { canvas, element: shape };
+    return { canvas, element: shape, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {

--- a/tests/c2d-text.test.ts
+++ b/tests/c2d-text.test.ts
@@ -6,20 +6,22 @@ import { mockMatchMedia, testReflection } from "./shared";
 import { setupJestCanvasMock } from "jest-canvas-mock";
 import { waitFor } from "@testing-library/dom";
 import { testShadow } from "./testShadow";
+import { ElementTestSetup } from "./types";
+import { Canvas2DText } from "../dist/types/elements/visual/text";
 
 describe("c2d-text", () => {
   setupJestCanvasMock();
 
   mockMatchMedia();
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DText> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
 
     const text = canvas.text();
 
-    return { canvas, element: text };
+    return { canvas, element: text, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {

--- a/tests/c2d-video.test.ts
+++ b/tests/c2d-video.test.ts
@@ -7,6 +7,8 @@ import { testRectangleBounds } from "./testRectangleBounds";
 import { testTransform } from "./testTransform";
 import { waitFor } from "@testing-library/dom";
 import { testShadow } from "./testShadow";
+import { ElementTestSetup } from "./types";
+import { Canvas2DVideo } from "../dist/types/elements/visual/video";
 
 describe("c2d-video", () => {
   mockMatchMedia();
@@ -19,7 +21,7 @@ describe("c2d-video", () => {
 
   const videoHeight = 45;
 
-  const setup = () => {
+  const setup: ElementTestSetup<Canvas2DVideo> = () => {
     const root = createRoot();
 
     const canvas = root.canvas2D();
@@ -65,7 +67,7 @@ describe("c2d-video", () => {
       },
     });
 
-    return { canvas, element: video };
+    return { canvas, element: video, teardown: root.remove.bind(root) };
   };
 
   afterEach(() => {

--- a/tests/createSetup.ts
+++ b/tests/createSetup.ts
@@ -1,0 +1,27 @@
+import { createRoot } from "web-spinner";
+import { ElementTestSetup } from "./types";
+import { Canvas2DCanvasElement } from "../dist/types/elements/visual/canvas";
+
+type Canvas2DElementChildName = {
+  [Key in keyof Canvas2DCanvasElement]: Canvas2DCanvasElement[Key] extends (
+    ...args: any
+  ) => Element
+    ? Key
+    : never;
+}[keyof Canvas2DCanvasElement];
+
+export function createCanvasElementSetup<T extends Element>(
+  method: Canvas2DElementChildName
+): ElementTestSetup<T> {
+  return () => {
+    const root = createRoot();
+
+    const canvas = root.canvas2D();
+
+    const element = canvas[method]();
+
+    const teardown = root.remove.bind(root);
+
+    return { canvas, element, teardown };
+  };
+}

--- a/tests/testFill.ts
+++ b/tests/testFill.ts
@@ -31,7 +31,7 @@ export function testFill(
 ) {
   describe("fill", () => {
     test("fill", async () => {
-      const { canvas, element } = setup();
+      const { canvas, element, teardown } = setup();
 
       let renderedFill: string | CanvasGradient | CanvasPattern;
 
@@ -108,6 +108,8 @@ export function testFill(
 
         testReflection(element, "fill", "fill", Color.rgb(225, 150, 75));
       }
+
+      teardown();
     });
   });
 }

--- a/tests/testOffset.ts
+++ b/tests/testOffset.ts
@@ -14,7 +14,7 @@ export function testOffset(
 ) {
   describe("offset", () => {
     test("coordinates passed into render function", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const offset = Vector2D.xy(7, 6);
 
@@ -33,20 +33,24 @@ export function testOffset(
           offset.y
         );
       });
+
+      teardown();
     });
 
     test("reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       const offset = Vector2D.xy(7, 6);
 
       element.offset = offset;
 
       testReflection(element, "offset", "offset", Vector2D.xy(5, 4));
+
+      teardown();
     });
 
     test("move offset", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const render = jest.spyOn(canvas.context, renderFunctionName);
 
@@ -73,6 +77,8 @@ export function testOffset(
           offset.y + movement.y
         );
       });
+
+      teardown();
     });
   });
 }

--- a/tests/testRectangleBounds.ts
+++ b/tests/testRectangleBounds.ts
@@ -24,7 +24,7 @@ export function testRectangleBounds(
 ) {
   describe("dimensions", () => {
     test("reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.width = 75;
 
@@ -33,10 +33,12 @@ export function testRectangleBounds(
       testReflection(element, "width", "width", 115);
 
       testReflection(element, "height", "height", 125);
+
+      teardown();
     });
 
     test("passed into render function", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const render = jest.spyOn(canvas.context, renderFunctionName);
 
@@ -63,11 +65,13 @@ export function testRectangleBounds(
           height * dimensionRenderScale
         );
       });
+
+      teardown();
     });
   });
 
   describe("rectangle bounds", () => {
-    const { element } = setup();
+    const { element, teardown } = setup();
 
     element.offset = Vector2D.xy(50, 65);
 
@@ -120,5 +124,7 @@ export function testRectangleBounds(
     test("reflection", () => {
       testReflection(element, "origin", "origin", "topLeft");
     });
+
+    teardown();
   });
 }

--- a/tests/testShadow.ts
+++ b/tests/testShadow.ts
@@ -9,7 +9,7 @@ export function testShadow(
 ) {
   describe("shadow", () => {
     test("renders", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const { context } = canvas;
 
@@ -32,6 +32,8 @@ export function testShadow(
       await waitFor(() => {
         expect(render).toHaveBeenCalled();
       });
+
+      teardown();
     });
   });
 }

--- a/tests/testStroke.ts
+++ b/tests/testStroke.ts
@@ -32,7 +32,7 @@ export function testStroke(
 ) {
   describe("stroke", () => {
     test("lineWidth", async () => {
-      const { canvas, element } = setup();
+      const { canvas, element, teardown } = setup();
 
       let renderedLineWidth = -1;
 
@@ -53,11 +53,13 @@ export function testStroke(
       });
 
       testReflection(element, "lineWidth", "line-width", 7);
+
+      teardown();
     });
   });
 
   test("stroke", async () => {
-    const { canvas, element } = setup();
+    const { canvas, element, teardown } = setup();
 
     let renderedStroke: string | CanvasGradient | CanvasPattern;
 
@@ -133,5 +135,7 @@ export function testStroke(
         expect(stroke).toHaveBeenCalledTimes(4);
       });
     }
+
+    teardown();
   });
 }

--- a/tests/testTransform.ts
+++ b/tests/testTransform.ts
@@ -17,7 +17,7 @@ export function testTransform(
 ) {
   describe("transform", () => {
     test("anchor", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const translate = jest.spyOn(canvas.context, "translate");
 
@@ -33,18 +33,22 @@ export function testTransform(
           anchor.y,
         ]);
       });
+
+      teardown();
     });
 
     test("anchor reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.anchor = Vector2D.xy(45, 65);
 
       testReflection(element, "anchor", "anchor", Vector2D.xy(-65, -45));
+
+      teardown();
     });
 
     test("angle", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const rotate = jest.spyOn(canvas.context, "rotate");
 
@@ -57,18 +61,22 @@ export function testTransform(
 
         expect(rotate.mock.calls[transformedParents][0]).toBe(angle.radians);
       });
+
+      teardown();
     });
 
     test("angle reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.angle = Angle.degrees(30);
 
       testReflection(element, "angle", "angle", Angle.degrees(-60));
+
+      teardown();
     });
 
     test("angular velocity", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const fps = 60;
 
@@ -87,16 +95,18 @@ export function testTransform(
 
         const currentDegrees = element.angle.degrees;
 
-        expect(movedFrames).toBeGreaterThanOrEqual(30);
+        expect(movedFrames).toEqual(30);
 
         expect(currentDegrees).toBeCloseTo(
           rotationPerFrame.degrees * movedFrames
         );
       });
+
+      teardown();
     });
 
     test("angular velocity reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.angularVelocity = Angle.degrees(30);
 
@@ -106,10 +116,12 @@ export function testTransform(
         "angular-velocity",
         Angle.degrees(60)
       );
+
+      teardown();
     });
 
     test("scale", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const scale = jest.spyOn(canvas.context, "scale");
 
@@ -126,18 +138,22 @@ export function testTransform(
           scaleValue.y,
         ]);
       });
+
+      teardown();
     });
 
     test("scale reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.scale = Vector2D.xy(1.5, 2.5);
 
       testReflection(element, "scale", "scale", Vector2D.xy(-2.5, -1.5));
+
+      teardown();
     });
 
     test("velocity", async () => {
-      const { element, canvas } = setup();
+      const { element, canvas, teardown } = setup();
 
       const fps = 60;
 
@@ -147,29 +163,41 @@ export function testTransform(
 
       const movementPerFrame = Vector2D.xy(velocity.x / fps, velocity.y / fps);
 
-      element.velocity = velocity;
-
       const applyMovement = jest.spyOn(element, "_applyMovement");
 
-      await waitFor(() => {
-        const movedFrames = applyMovement.mock.calls.length - 1;
+      const movedFrames = 30;
 
-        const { x, y } = element.anchor;
+      const { x, y } = await new Promise<{ x: number; y: number }>(
+        (resolve) => {
+          canvas.everyFrame = (frame: number) => {
+            if (frame === movedFrames) {
+              expect(applyMovement.mock.calls.length).toEqual(movedFrames);
 
-        expect(movedFrames).toBeGreaterThanOrEqual(30);
+              const { x, y } = element.anchor;
 
-        expect(x).toBeCloseTo(movementPerFrame.x * movedFrames, 0);
+              resolve({ x, y });
+            }
+          };
 
-        expect(y).toBeCloseTo(movementPerFrame.y * movedFrames, 0);
-      });
+          element.velocity = velocity;
+        }
+      );
+
+      expect(x).toBeCloseTo(movementPerFrame.x * (movedFrames - 1), 0);
+
+      expect(y).toBeCloseTo(movementPerFrame.y * (movedFrames - 1), 0);
+
+      teardown();
     });
 
     test("velocity reflection", () => {
-      const { element } = setup();
+      const { element, teardown } = setup();
 
       element.velocity = Vector2D.xy(1, 2);
 
       testReflection(element, "velocity", "velocity", Vector2D.xy(3, 4));
+
+      teardown();
     });
   });
 }

--- a/tests/testTransform.ts
+++ b/tests/testTransform.ts
@@ -183,9 +183,9 @@ export function testTransform(
         }
       );
 
-      expect(x).toBeCloseTo(movementPerFrame.x * (movedFrames - 1), 0);
+      expect(x).toBeCloseTo(movementPerFrame.x * (movedFrames - 1));
 
-      expect(y).toBeCloseTo(movementPerFrame.y * (movedFrames - 1), 0);
+      expect(y).toBeCloseTo(movementPerFrame.y * (movedFrames - 1));
 
       teardown();
     });

--- a/tests/types.d.ts
+++ b/tests/types.d.ts
@@ -3,12 +3,8 @@ import { Canvas2DCanvasElement } from "../dist/types/elements/visual/canvas";
 type ElementTestSetup<T> = () => {
   canvas: Canvas2DCanvasElement;
   element: Element & T;
+  teardown: () => void;
 };
-
-type ElementTestTeardown = (
-  canvas: Canvas2DCanvasElement,
-  element: Element
-) => void;
 
 type VoidCanvasMethods = {
   [Key in keyof CanvasRenderingContext2D as ((


### PR DESCRIPTION
Bug: `toPrecision` on `Vector2D`'s `toString` was causing elements to stick when they reach 4 figure anchor x/y values. `toFixed` is the more appropriate method.

Rework velocity test for better precision, and use teardown after tests to remove elements