### PR TITLE
Queue render when pixel ratio changes

### DIFF
--- a/src/elements/visual/canvas.ts
+++ b/src/elements/visual/canvas.ts
@@ -371,6 +371,8 @@ export class Canvas2DCanvasElement extends c2dStandaloneChildren(C2DBase) {
     this.domCanvas.height *= scaleRatio;
 
     this.#devicePixelRatio = newPixelRatio;
+
+    this.queueRender();
   }
 
   waitFor(element: Element, eventName: keyof HTMLElementEventMap = "load") {


### PR DESCRIPTION
When moving static canvas from one display to another, canvas would not rerender. This fixes that issue.